### PR TITLE
[FIX]記事一覧画面の修正

### DIFF
--- a/article.html
+++ b/article.html
@@ -22,16 +22,11 @@
     <script>
       document.addEventListener("DOMContentLoaded", function () {
         const details = document.querySelectorAll(".detail");
-
-        // 初期状態でREVIEWを選択状態にする
         details[0].classList.add("selected");
-
-        // detailをクリックしたときの処理
         details.forEach((detail) => {
           detail.addEventListener("click", function () {
-            // すべてのdetailからselectedクラスを削除
             details.forEach((d) => d.classList.remove("selected"));
-            // クリックされたdetailにselectedクラスを追加
+
             this.classList.add("selected");
           });
         });
@@ -43,33 +38,43 @@
         const langButtons = document.querySelectorAll(
           ".lang-btns-container button"
         );
-
-        // 初期状態で日本語を選択状態にする
         langButtons[0].classList.add("selected");
-
-        // lang-btnをクリックしたときの処理
         langButtons.forEach((button) => {
           button.addEventListener("click", function () {
-            // すべてのlang-btnからselectedクラスを削除
             langButtons.forEach((btn) => btn.classList.remove("selected"));
-            // クリックされたlang-btnにselectedクラスを追加
+
             this.classList.add("selected");
           });
         });
       });
-      s;
+    </script>
+
+    <script>
+      window.addEventListener("scroll", function () {
+        var header = document.querySelector("header");
+        var scrollTop =
+          window.pageYOffset || document.documentElement.scrollTop;
+
+        if (scrollTop > 0) {
+          header.classList.add("fixed-header");
+        } else {
+          header.classList.remove("fixed-header");
+        }
+      });
     </script>
   </head>
 
   <body>
-    <header>
+    <header class="fixed-header">
       <div class="header-container">
-        <p class="header-title">KAMUY&nbsp;LUMINA&nbsp;SPECIAL&nbsp;SITE</p>
-        <div class="detail-container">
+        <a href="index.html">
+          <p class="header-title">KAMUY&nbsp;LUMINA&nbsp;SPECIAL&nbsp;SITE</p>
+        </a>
+        <!-- <div class="detail-container">
           <p class="detail" data-detail="REVIEW">REVIEW</p>
           <p class="detail" data-detail="ACCESS">ACCESS</p>
           <p class="detail" data-detail="GALLERY">GALLERY</p>
-        </div>
+        </div> -->
         <div class="right-side-btn">
           <div class="lang-btns-container">
             <button class="lang-btn1" data-btn="langBtn1">日本語</button>
@@ -94,7 +99,7 @@
           </div>
         </div>
         <div class="navbar">
-          <div class="hamburger-icon">
+          <div class="hamburger-icon" id="hamburger-button">
             <div class="line"></div>
             <div class="line"></div>
             <div class="line"></div>
@@ -102,7 +107,7 @@
         </div>
       </div>
     </header>
-    <div class="ArticleMainContainer">
+    <div class="article_main_container">
       <p class="ArticleTitle">記事一覧</p>
       <p class="SubText">ARTICLE LIST</p>
     </div>
@@ -110,188 +115,254 @@
       <div class="Container">
         <div class="MiddleContainer">
           <div class="TextContainer">
-            <p class="TextAll">すべて</p>
+            <a class="article_a" href="">
+              <p class="TextAll">すべて</p>
+            </a>
           </div>
           <div class="TextContainer">
-            <p class="Text">おすすめスポット</p>
-            <p class="Text">まちの自然</p>
-            <p class="Text">まちの歴史</p>
+            <a class="article_a" href="">
+              <p class="Text">おすすめスポット</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">まちの自然</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">まちの歴史</p>
+            </a>
           </div>
           <div class="TextContainer">
-            <p class="Text">まちの食文化</p>
-            <p class="Text">アクティビティ</p>
-            <p class="Text">季節別の楽しみ</p>
+            <a class="article_a" href="">
+              <p class="Text">まちの食文化</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">アクティビティ</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">季節別の楽しみ</p>
+            </a>
           </div>
           <div class="TextContainer">
-            <p class="Text">まちの恒例行事</p>
-            <p class="Text">人の暮らし紹介</p>
-            <p class="Text">ルミナスタッフのススメ</p>
+            <a class="article_a" href="">
+              <p class="Text">まちの恒例行事</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">人の暮らし紹介</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">ルミナスタッフのススメ</p>
+            </a>
           </div>
         </div>
 
         <div class="MiddleContainerSP">
           <div class="TextContainer">
-            <p class="TextAll">すべて</p>
-            <p class="Text">まちの食文化</p>
-            <p class="Text">まちの自然</p>
-            <p class="Text">人の暮らし紹介</p>
-            <p class="Text">季節別の楽しみ</p>
+            <a class="article_a" href="">
+              <p class="TextAll">すべて</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">まちの食文化</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">まちの自然</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">人の暮らし紹介</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">季節別の楽しみ</p>
+            </a>
           </div>
           <div class="TextContainer">
-            <p class="Text">おすすめスポット</p>
-            <p class="Text">まちの恒例行事</p>
-            <p class="Text">アクティビティ</p>
-            <p class="Text">まちの歴史</p>
-            <p class="Text">ルミナスタッフのススメ</p>
+            <a class="article_a" href="">
+              <p class="Text">おすすめスポット</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">まちの恒例行事</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">アクティビティ</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">まちの歴史</p>
+            </a>
+            <a class="article_a" href="">
+              <p class="Text">ルミナスタッフのススメ</p>
+            </a>
           </div>
         </div>
 
         <div class="SpotContainer">
-          <div class="Line">
+          <div class="spot_line">
             <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card1.png"
-                alt="Spot 1"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card1.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
             </div>
             <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card2.png"
-                alt="Spot 2"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card2.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
             </div>
             <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card3.png"
-                alt="Spot 3"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
-            </div>
-          </div>
-          <div class="Line">
-            <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card4.png"
-                alt="Spot 4"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
-            </div>
-            <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card5.png"
-                alt="Spot 5"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
-            </div>
-            <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card6.png"
-                alt="Spot 6"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card3.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
             </div>
           </div>
-          <div class="Line">
+          <div class="spot_line">
             <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card7.png"
-                alt="Spot 4"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card4.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
             </div>
             <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card8.png"
-                alt="Spot 5"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card5.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
             </div>
             <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card9.png"
-                alt="Spot 6"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
-            </div>
-          </div>
-          <div class="Line">
-            <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card10.png"
-                alt="Spot 4"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
-            </div>
-            <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card11.png"
-                alt="Spot 5"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
-            </div>
-            <div class="SpotCard">
-              <div class="Tag">おすすめスポット</div>
-              <img
-                class="SpotImage"
-                src="assets/article/article_card12.png"
-                alt="Spot 6"
-              />
-              <p class="SpotText">
-                今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
-              </p>
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card6.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
             </div>
           </div>
+          <div class="spot_line">
+            <div class="SpotCard">
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card7.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
+            </div>
+            <div class="SpotCard">
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card8.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
+            </div>
+            <div class="SpotCard">
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card9.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
+            </div>
+          </div>
+          <div class="spot_line">
+            <div class="SpotCard">
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card10.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
+            </div>
+            <div class="SpotCard">
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card11.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
+            </div>
+            <div class="SpotCard">
+              <a class="card_a" href="article_detailes.html">
+                <div class="Tag">おすすめスポット</div>
+                <img
+                  class="spot_image"
+                  src="assets/article/article_card12.png"
+                  alt="Spot"
+                />
+                <p class="spot_text">
+                  今回の舞台は、北海道、阿寒摩周国立公園にある阿寒湖。
+                </p>
+              </a>
+            </div>
+          </div>
+          <!-- ここまで元々表示 -->
         </div>
       </div>
-      <div class="MoreBtn">
+      <div class="more_btn" id="moreButton">
         <p class="BtnText">VIEW MORE <span class="Plus">+</span></p>
       </div>
+      <script src="js/spot_more.js"></script>
     </div>
 
     <div class="container">
@@ -338,7 +409,7 @@
       />
       <p class="footer_text">KAMUY LUMINA SPECIAL SITE</p>
       <div class="btn-container">
-        <div class="official-btn_footer">
+        <div class="official-btn">
           オフィシャルサイト
           <img
             class="arrow-image"

--- a/article_detailes.html
+++ b/article_detailes.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>記事詳細</title>
+  </head>
+  <body>
+    <div>記事詳細</div>
+  </body>
+</html>

--- a/css/article.css
+++ b/css/article.css
@@ -1,4 +1,4 @@
-.ArticleMainContainer {
+.article_main_container {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/css/article_middle.css
+++ b/css/article_middle.css
@@ -62,6 +62,14 @@
   }
 }
 
+.article_a {
+  text-decoration: none;
+}
+
+.article_a:hover {
+  opacity: 0.5;
+}
+
 .TextAll {
   color: #002c4b;
   font-family: "Noto Serif JP", serif;
@@ -91,7 +99,7 @@
   }
 }
 
-.Line {
+.spot_line {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -99,7 +107,7 @@
 }
 
 @media screen and (max-width: 768px) {
-  .Line {
+  .spot_line {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -109,6 +117,10 @@
 .SpotCard {
   flex-direction: column;
   margin: 0 25px;
+}
+
+.card_a {
+  text-decoration: none;
 }
 
 .Tag {
@@ -130,7 +142,7 @@
   }
 }
 
-.SpotImage {
+.spot_image {
   width: 270px;
   height: 162px;
   object-fit: cover;
@@ -140,34 +152,49 @@
 }
 
 @media screen and (max-width: 768px) {
-  .SpotImage {
+  .spot_image {
     display: flex;
     align-items: center;
     justify-content: center;
     width: 340px;
     height: 204px;
+    transition: transform 0.3s ease;
   }
 }
 
-.SpotText {
+.spot_image:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.8);
+}
+
+.spot_text {
   font-family: "Noto Serif JP", serif;
   color: #002c4b;
   font-size: 13px;
   padding: 8px;
 }
 
+.spot_text:hover {
+  opacity: 0.5;
+}
+
 @media screen and (max-width: 768px) {
-  .SpotText {
+  .spot_text {
     padding: 8px;
   }
 }
 
-.MoreBtn {
+.more_btn {
   display: flex;
   justify-content: center;
   margin-top: 10px;
   margin-bottom: 50px;
   cursor: pointer;
+  transition: opacity 0.3s ease;
+}
+
+.more_btn:hover {
+  opacity: 0.4;
 }
 
 .BtnText {
@@ -177,8 +204,23 @@
   padding-bottom: 5px;
 }
 
+.page-top-btn {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  transition: opacity 0.3s ease;
+}
+
+.page-top-btn:hover {
+  opacity: 0.4;
+}
+
 .Plus {
   font-size: 15px;
   margin-left: 4px;
   color: #a4b1ba;
+}
+
+.spot_line_hidden {
+  display: none;
 }

--- a/css/header.css
+++ b/css/header.css
@@ -1,6 +1,12 @@
+.fixed-header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+}
+
 .header-container {
   display: flex;
-  justify-content: space-evenly;
+  justify-content: space-between;
   align-items: center;
   padding: 30px;
   background-color: #002c4b;
@@ -17,6 +23,10 @@
   font-size: 14px;
   font-family: "Poppins", sans-serif;
   color: white;
+}
+
+.header-title:hover {
+  opacity: 0.5;
 }
 
 .detail-container {
@@ -130,9 +140,17 @@
   margin-right: 20px;
 }
 
+.official-btn:hover {
+  opacity: 0.5;
+}
+
 .ticket-btn {
   background-color: #ffffff;
   color: #002c4b;
+}
+
+.ticket-btn:hover {
+  opacity: 0.5;
 }
 
 .arrow-image {

--- a/index.html
+++ b/index.html
@@ -10,10 +10,17 @@
         window.location.href = "article.html";
       }
     </script>
+
+    <script>
+      function redirectToArticleTest() {
+        window.location.href = "test.html";
+      }
+    </script>
   </head>
   <body>
     <div>
       <button onclick="redirectToArticle()">記事一覧画面</button>
+      <button onclick="redirectToArticleTest()">test</button>
     </div>
   </body>
 </html>

--- a/js/spot_more.js
+++ b/js/spot_more.js
@@ -1,0 +1,10 @@
+document.getElementById("moreButton").addEventListener("click", function () {
+  var hiddenText = document.getElementById("hiddenContainer");
+  if (hiddenText.classList.contains("hidden")) {
+    hiddenText.classList.remove("hidden");
+    document.getElementById("moreButton");
+  } else {
+    hiddenText.classList.add("hidden");
+    document.getElementById("moreButton");
+  }
+});


### PR DESCRIPTION
### 下記修正
ヘッダーは固定ヘッダー
REVIEW　ACCESS　GALLERYは記事一覧からははずしてください
KAMUY LUMINA SPECIAL SITEの部分は、トップページへの遷移（aタグつけてください）
aタグは、マウスオーバーで透過するなどの処理
記事はスクショの範囲内を押下すると記事詳細にとぶような設計
マウスオーバー時、透過処理など（浮かび上がるような処理でもよい）
ページトップへの動線を、fixedでページ右下部に常に表示
ページトップへの動線をhoverで透過処理